### PR TITLE
[COA-2971] Fix Union interval bounds validation to prevent panic

### DIFF
--- a/interval/interval.go
+++ b/interval/interval.go
@@ -98,10 +98,13 @@ func Union(a []Interval, b []Interval) []Interval {
 			i++
 		}
 
-		result = append(result, Interval{
-			Start: start,
-			End:   end,
-		})
+		// Only append if the intervals actually overlap (start <= end)
+		if start <= end {
+			result = append(result, Interval{
+				Start: start,
+				End:   end,
+			})
+		}
 	}
 
 	return joinSortedIntervals(result)

--- a/interval/interval_test.go
+++ b/interval/interval_test.go
@@ -77,6 +77,28 @@ func TestUnion(t *testing.T) {
 				{Start: 5, End: 5},
 			},
 		},
+		{
+			name: "non-overlapping intervals should produce empty result",
+			a: []interval.Interval{
+				{Start: 90, End: 95},
+			},
+			b: []interval.Interval{
+				{Start: 80, End: 88},
+			},
+			e: []interval.Interval{},
+		},
+		{
+			name: "adjacent but non-overlapping intervals",
+			a: []interval.Interval{
+				{Start: 10, End: 20},
+				{Start: 50, End: 60},
+			},
+			b: []interval.Interval{
+				{Start: 21, End: 30},
+				{Start: 40, End: 49},
+			},
+			e: []interval.Interval{},
+		},
 	}
 
 	for _, tc := range testacses {


### PR DESCRIPTION
## What

- Add bounds validation in `interval.Union()` to check `start <= end` before appending intervals to the result
- Add test cases for non-overlapping and adjacent interval scenarios that previously caused panics

## Why

### The Problem

The `Union` function panics when processing certain file/coverage combinations:

```
panic: runtime error: slice bounds out of range [90:88]

goroutine 1 [running]:
github.com/panagiotisptr/cov-diff/interval.TotalWhitespace(...)
    /cov-diff/interval/interval.go:46 +0xf0
```

This was discovered in [rewardStyle/engx#4](https://github.com/rewardStyle/engx/pull/4).

### Root Cause

The `Union` function computes interval intersections by independently calculating:
- `start = max(a.Start, b.Start)` 
- `end = min(a.End, b.End)`

When two intervals don't actually overlap, this produces an invalid interval where `start > end`:

```
Interval A: [90, 95]  (diff says lines 90-95 changed)
Interval B: [80, 88]  (file has code on lines 80-88)

Union computes:
  start = max(90, 80) = 90
  end   = min(95, 88) = 88
  
Result: [90, 88]  ← INVALID (start > end)
```

This invalid interval is passed to `TotalWhitespace()` which attempts `lines[90:88]`, causing the panic.

### Why This Bug Hasn't Been Seen Before

**Every repo using build-utils has these default coverage filters:**

```makefile
# From .build-utils/applications/go/Makefile
GO_TEST_COVERAGE_FILTERS += /testing/ \
    /cmd/ \
    /mocks/
```

These filters are applied when creating `parsed_coverage.out`:

```bash
grep -v $(foreach filter,$(GO_TEST_COVERAGE_FILTERS),-e '$(filter)') coverage.out > parsed_coverage.out
```

**This means `/cmd/` files are excluded from coverage analysis in every existing repo.**

The engx repo is a CLI tool that lives entirely in `cmd/ktl/`. It doesn't use build-utils, so it passed unfiltered coverage data to cov-diff. This is the first time cov-diff has ever processed `/cmd/` files, which happen to have interval patterns that trigger this edge case.

### The Fix

Add validation to ensure `start <= end` before appending:

```go
if start <= end {
    result = append(result, Interval{
        Start: start,
        End:   end,
    })
}
```

This correctly handles non-overlapping intervals by excluding them from the result.